### PR TITLE
Refactor annotation label editing and add tooltip UI

### DIFF
--- a/frontend/lib/modules/annotation/components/annotation_list_widget.dart
+++ b/frontend/lib/modules/annotation/components/annotation_list_widget.dart
@@ -1,4 +1,5 @@
 import 'package:auto_ml/i18n/strings.g.dart';
+import 'package:auto_ml/modules/annotation/components/editable_text.dart';
 import 'package:auto_ml/modules/annotation/notifiers/annotation_notifier.dart';
 import 'package:auto_ml/modules/current_dataset_annotation_notifier.dart';
 import 'package:auto_ml/utils/styles.dart';
@@ -95,7 +96,7 @@ class _AnnotationListWidgetState extends ConsumerState<AnnotationListWidget> {
                             child: Row(
                               children: [
                                 Expanded(
-                                  child: _EditableLabel(
+                                  child: EditableLabel(
                                     onTap: () {
                                       ref
                                           .read(
@@ -215,92 +216,6 @@ class _AnnotationListWidgetState extends ConsumerState<AnnotationListWidget> {
             ),
           ],
         ),
-      ),
-    );
-  }
-}
-
-class _EditableLabel extends StatefulWidget {
-  const _EditableLabel({
-    required this.label,
-    required this.onSubmit,
-    required this.onTap,
-  });
-  final String label;
-  final void Function(String) onSubmit;
-  final VoidCallback onTap;
-
-  @override
-  State<_EditableLabel> createState() => __EditableLabelState();
-}
-
-class __EditableLabelState extends State<_EditableLabel> {
-  bool isEditing = false;
-
-  late final TextEditingController controller =
-      TextEditingController()..text = widget.label;
-
-  FocusNode focusNode = FocusNode();
-
-  @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
-  void didUpdateWidget(covariant _EditableLabel oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    controller.text = widget.label;
-  }
-
-  @override
-  void dispose() {
-    controller.dispose();
-    focusNode.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () {
-        widget.onTap();
-      },
-      onDoubleTap: () {
-        setState(() {
-          isEditing = true;
-        });
-        focusNode.requestFocus();
-      },
-      child: SizedBox(
-        height: 20,
-        child:
-            isEditing
-                ? TextField(
-                  focusNode: focusNode,
-                  style: TextStyle(fontSize: 12),
-                  decoration: InputDecoration(
-                    contentPadding: EdgeInsets.only(
-                      top: 10,
-                      left: 10,
-                      right: 10,
-                    ),
-                    border: OutlineInputBorder(),
-                    focusedBorder: OutlineInputBorder(
-                      borderSide: BorderSide(color: Colors.blueAccent),
-                    ),
-                    hintText: "New Type",
-                    hintStyle: TextStyle(fontSize: 12, color: Colors.grey),
-                  ),
-                  controller: controller,
-                  onSubmitted: (value) {
-                    setState(() {
-                      isEditing = false;
-                    });
-                    widget.onSubmit(controller.text);
-                  },
-                )
-                : Text(controller.text),
       ),
     );
   }

--- a/frontend/lib/modules/annotation/components/editable_text.dart
+++ b/frontend/lib/modules/annotation/components/editable_text.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+class EditableLabel extends StatefulWidget {
+  const EditableLabel({
+    super.key,
+    required this.label,
+    required this.onSubmit,
+    required this.onTap,
+  });
+  final String label;
+  final void Function(String) onSubmit;
+  final VoidCallback onTap;
+
+  @override
+  State<EditableLabel> createState() => _EditableLabelState();
+}
+
+class _EditableLabelState extends State<EditableLabel> {
+  bool isEditing = false;
+
+  late final TextEditingController controller =
+      TextEditingController()..text = widget.label;
+
+  FocusNode focusNode = FocusNode();
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  void didUpdateWidget(covariant EditableLabel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    controller.text = widget.label;
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        widget.onTap();
+      },
+      onDoubleTap: () {
+        setState(() {
+          isEditing = true;
+        });
+        focusNode.requestFocus();
+      },
+      child: SizedBox(
+        height: 20,
+        child:
+            isEditing
+                ? TextField(
+                  focusNode: focusNode,
+                  style: TextStyle(fontSize: 12),
+                  decoration: InputDecoration(
+                    contentPadding: EdgeInsets.only(
+                      top: 10,
+                      left: 10,
+                      right: 10,
+                    ),
+                    border: OutlineInputBorder(),
+                    focusedBorder: OutlineInputBorder(
+                      borderSide: BorderSide(color: Colors.blueAccent),
+                    ),
+                    hintText: "New Type",
+                    hintStyle: TextStyle(fontSize: 12, color: Colors.grey),
+                  ),
+                  controller: controller,
+                  onSubmitted: (value) {
+                    setState(() {
+                      isEditing = false;
+                    });
+                    widget.onSubmit(controller.text);
+                  },
+                )
+                : Text(controller.text),
+      ),
+    );
+  }
+}

--- a/frontend/lib/modules/annotation/components/image_board.dart
+++ b/frontend/lib/modules/annotation/components/image_board.dart
@@ -215,21 +215,20 @@ class _ImageBoardState extends ConsumerState<ImageBoard> {
                               //   "annotations length: ${annotations.length}",
                               // );
                               return Stack(
-                                children:
-                                    annotations.annotations
-                                        .map(
-                                          (e) => AnnotationWidget(
-                                            classes:
-                                                ref
-                                                    .read(
-                                                      currentDatasetAnnotationNotifierProvider,
-                                                    )
-                                                    .classes,
+                                children: [
+                                  ...annotations.annotations.map(
+                                    (e) => AnnotationWidget(
+                                      classes:
+                                          ref
+                                              .read(
+                                                currentDatasetAnnotationNotifierProvider,
+                                              )
+                                              .classes,
 
-                                            uuid: e.uuid,
-                                          ),
-                                        )
-                                        .toList(),
+                                      uuid: e.uuid,
+                                    ),
+                                  ),
+                                ],
                               );
                             },
                           ),

--- a/frontend/lib/modules/annotation/label_screen.dart
+++ b/frontend/lib/modules/annotation/label_screen.dart
@@ -7,6 +7,7 @@ import 'package:auto_ml/modules/current_dataset_annotation_notifier.dart';
 import 'package:auto_ml/modules/annotation/components/file_list.dart';
 import 'package:auto_ml/modules/annotation/components/icons.dart';
 import 'package:auto_ml/modules/annotation/components/image_board.dart';
+import 'package:auto_ml/utils/globals.dart';
 import 'package:auto_ml/utils/logger.dart';
 import 'package:auto_ml/utils/styles.dart';
 import 'package:flutter/material.dart';
@@ -107,7 +108,9 @@ class _LabelScreenState extends ConsumerState<LabelScreen> {
                   spacing: 10,
                   children: [
                     FileList(),
-                    Expanded(child: ImageBoard()),
+                    Expanded(
+                      child: ImageBoard(key: Globals.globalImageBoardKey),
+                    ),
                     AnnotationListWidget(
                       classes:
                           ref

--- a/frontend/lib/modules/annotation/notifiers/annotation_notifier.dart
+++ b/frontend/lib/modules/annotation/notifiers/annotation_notifier.dart
@@ -974,9 +974,14 @@ class SingleAnnotationNotifier
   }
 
   void changeAnnotationClassId(int classId) {
+    if (classId == -1) {
+      ToastUtils.error(null, title: "Class not found");
+      return;
+    }
     state = state.copyWith(id: classId);
     final container = ref.read(annotationContainerProvider.notifier);
     container.update(uuid: state.uuid, annotation: state);
+    container.annotationFinalize();
   }
 
   void updateDone() {

--- a/frontend/lib/utils/globals.dart
+++ b/frontend/lib/utils/globals.dart
@@ -1,10 +1,13 @@
 import 'package:file_selector/file_selector.dart';
+import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 class Globals {
   Globals._();
 
   static String appVersion = '';
+
+  static GlobalKey globalImageBoardKey = GlobalKey();
 
   static const XTypeGroup imageType = XTypeGroup(
     label: 'images',

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -1179,6 +1179,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  super_tooltip:
+    dependency: "direct main"
+    description:
+      name: super_tooltip
+      sha256: "06f734caa2ddb2313813dac2c939f096222beece9c146ec7d71e07e6e869bef2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   synchronized:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   riverpod: ^2.6.1
   slang: ^4.7.1
   slang_flutter: ^4.7.0
+  super_tooltip: ^2.1.0
   timelines_plus: ^1.0.6
   toastification: ^3.0.2
   toggle_switch: ^2.3.0


### PR DESCRIPTION
Moved the editable label widget to a reusable component (EditableLabel) and integrated it into annotation list and annotation widgets. Added a tooltip UI for editing annotation labels using the super_tooltip package. Updated annotation class ID change logic to handle invalid classes and finalize annotation updates. Added a global key for the image board and updated dependencies.